### PR TITLE
Fix Connection Retries

### DIFF
--- a/fluxer/http.py
+++ b/fluxer/http.py
@@ -248,6 +248,7 @@ class HTTPClient:
                     )
 
             except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+                self._rate_limiter.release(route.bucket, {})
                 if attempt < 4:
                     log.warning(
                         "Connection error: %s, retrying (attempt %d)", exc, attempt + 1


### PR DESCRIPTION
Currently, when a connection error occurs, a bot using this library might spit out a log line like:
```
WARNING:fluxer.http:Connection error: Cannot connect to host api.fluxer.app:443 ssl:default [Connection reset by peer], retrying (attempt 1)
```
but no retry attempt ever occurs. 

This happens because on the first attempt of a request a lock is acquired at line 191, but never released. Since this is never released, when that line is called again and we hit `await lock.acquire()`, a deadlock occurs waiting forever on a lock that will never release. 

This PR adds a lock release to the exception handling, that way the retry attempts can go through. You can test this pretty easily by disabling your internet connection and running a bot, you should witness retries going through. 