### PR TITLE
Add Bulk Message Deletion Endpoint + Add Bulk Fetching/Deleting Messages to Channel

### DIFF
--- a/fluxer/client.py
+++ b/fluxer/client.py
@@ -453,13 +453,11 @@ class Client:
                 token,
                 api_url=self.api_url,
                 max_retries=self._max_retries,
-                retry_forever=self._retry_forever
+                retry_forever=self._retry_forever,
             )
         else:
             self._http = HTTPClient(
-                token,
-                max_retries=self._max_retries,
-                retry_forever=self._retry_forever
+                token, max_retries=self._max_retries, retry_forever=self._retry_forever
             )
 
         self._gateway = Gateway(
@@ -525,8 +523,8 @@ class Bot(Client):
         command_prefix: str = "!",
         intents: Intents = Intents.default(),
         api_url: str | None = None,
-        max_retries: int = 4,         
-        retry_forever: bool = False, 
+        max_retries: int = 4,
+        retry_forever: bool = False,
     ) -> None:
         super().__init__(intents=intents, api_url=api_url)
         self.command_prefix = command_prefix

--- a/fluxer/http.py
+++ b/fluxer/http.py
@@ -130,7 +130,15 @@ class HTTPClient:
                  Use this to connect to self-hosted Fluxer instances
     """
 
-    def __init__(self, token: str, *, is_bot: bool = True, api_url: str = DEFAULT_API_URL, max_retries=4, retry_forever=False) -> None:
+    def __init__(
+        self,
+        token: str,
+        *,
+        is_bot: bool = True,
+        api_url: str = DEFAULT_API_URL,
+        max_retries=4,
+        retry_forever=False,
+    ) -> None:
         self.token = token
         self.is_bot = is_bot
         self.api_url = api_url.rstrip("/")  # Remove trailing slash if present
@@ -175,8 +183,8 @@ class HTTPClient:
         data: aiohttp.FormData | None = None,
         params: dict[str, Any] | None = None,
         reason: str | None = None,
-        max_retries: int | None = None,       
-        retry_forever: bool | None = None,     
+        max_retries: int | None = None,
+        retry_forever: bool | None = None,
     ) -> Any:
         """Make an authenticated request to the Fluxer API.
 
@@ -238,7 +246,9 @@ class HTTPClient:
                             await asyncio.sleep(retry_after)
                         attempt += 1
                         if not retry_forever and attempt > max_retries:
-                            raise RuntimeError(f"Failed after {attempt} attempts: {route.method} {route.url}")
+                            raise RuntimeError(
+                                f"Failed after {attempt} attempts: {route.method} {route.url}"
+                            )
                         continue
 
                     # Server error — retry
@@ -252,7 +262,9 @@ class HTTPClient:
                         await asyncio.sleep(1 + attempt)
                         attempt += 1
                         if not retry_forever and attempt > max_retries:
-                            raise RuntimeError(f"Failed after {attempt} attempts: {route.method} {route.url}")
+                            raise RuntimeError(
+                                f"Failed after {attempt} attempts: {route.method} {route.url}"
+                            )
                         continue
 
                     # Client error — raise
@@ -481,6 +493,18 @@ class HTTPClient:
             message_id=message_id,
         )
         await self.request(route)
+
+    async def delete_messages(
+        self, channel_id: int | str, message_ids: list[int | str]
+    ) -> None:
+        """POST /channels/{channel_id}/messages/bulk-delete"""
+        route = self._route(
+            "POST",
+            "/channels/{channel_id}/messages/bulk-delete",
+            channel_id=channel_id,
+        )
+        payload = {"message_ids": [str(mid) for mid in message_ids]}
+        await self.request(route, json=payload)
 
     # -- Guilds --
     async def get_guild(self, guild_id: int | str) -> dict[str, Any]:

--- a/fluxer/models/channel.py
+++ b/fluxer/models/channel.py
@@ -151,6 +151,35 @@ class Channel:
         data = await self._http.get_message(self.id, message_id)
         return Message.from_data(data, self._http)
 
+    async def fetch_messages(self, limit: int = 50) -> list[Message]:
+        """Fetch recent messages from this channel.
+
+        Args:
+            limit: The maximum number of messages to fetch (default 50).
+
+        Returns:
+            A list of Message objects.
+        """
+        from .message import Message
+
+        if self._http is None:
+            raise RuntimeError("Channel is not bound to an HTTP client")
+
+        data = await self._http.get_messages(self.id, limit=limit)
+        return [Message.from_data(msg_data, self._http) for msg_data in data]
+
+    async def delete_messages(self, message_ids: list[int | str]) -> None:
+        """Bulk delete messages in this channel.
+
+        Args:
+            message_ids: A list of message IDs to delete.
+
+        """
+        if self._http is None:
+            raise RuntimeError("Channel is not bound to an HTTP client")
+
+        await self._http.delete_messages(self.id, message_ids)
+
     def __eq__(self, other: object) -> bool:
         return isinstance(other, Channel) and self.id == other.id
 


### PR DESCRIPTION
This PR adds the message bulk deletion endpoint to the library, and then adds bulk fetching and deleting of messages via a channel object. 

Sorry that the diff isn't super clean, something got merged without ruff formatting being done. 

If anyone wants to test, simple bot that I used just to verify it worked:

```py
import fluxer

bot = fluxer.Bot(command_prefix="!", intents=fluxer.Intents.default())

token = "<token>"

@bot.command()
async def delete_messages(ctx: fluxer.Message, channel_arg: str):
    channel_id = int(channel_arg)
    channel = await bot.fetch_channel(channel_id)
    messages = await channel.fetch_messages(limit=5)
    message_ids = [message.id for message in messages]
    await channel.delete_messages(message_ids)
    await ctx.reply("Deleted the last 5 messages!")


if __name__ == "__main__":
    bot.run(token)

```