### PR TITLE
Add permissions decorators for commands

### DIFF
--- a/fluxer/__init__.py
+++ b/fluxer/__init__.py
@@ -10,6 +10,9 @@ from .enums import ChannelType, GatewayCloseCode, GatewayOpcode, Intents, Permis
 from .file import File
 from .http import HTTPClient
 
+# Checks
+from .checks import has_role, has_permission
+
 # Errors
 from .errors import (
     BadRequest,
@@ -41,6 +44,9 @@ from .models import (
 from .utils import datetime_to_snowflake, snowflake_to_datetime
 
 __all__ = [
+    # Checks
+    "has_role",
+    "has_permission",
     # Client
     "Bot",
     "Client",

--- a/fluxer/__init__.py
+++ b/fluxer/__init__.py
@@ -6,7 +6,7 @@ __license__ = "MIT"
 # Core classes
 from .client import Bot, Client
 from .cog import Cog
-from .enums import ChannelType, GatewayCloseCode, GatewayOpcode, Intents
+from .enums import ChannelType, GatewayCloseCode, GatewayOpcode, Intents, Permissions
 from .file import File
 from .http import HTTPClient
 
@@ -52,6 +52,7 @@ __all__ = [
     "GatewayCloseCode",
     "GatewayOpcode",
     "Intents",
+    "Permissions",
     # Errors
     "BadRequest",
     "FluxerException",

--- a/fluxer/checks.py
+++ b/fluxer/checks.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import asyncio
+import functools
+from typing import Callable, Coroutine, Any
+
+from .enums import Permissions
+from .models.member import GuildMember
+from .models.message import Message
+
+EventHandler = Callable[..., Coroutine[Any, Any, None]]
+
+
+def has_role(
+    name: str | None = None, id: int | str | None = None
+) -> Callable[[EventHandler], EventHandler]:
+    """Restrict a command to users who have a specific role.
+
+    Works with both standalone commands and cog methods. Can be identified
+    by role name (str) or role ID (int). Role name matching is case-sensitive.
+
+    Args:
+        name: Role name (str) to require.
+        id: Role ID (int or str) to require.
+
+    Example:
+        @bot.command()
+        @fluxer.checks.has_role(name="Moderator")
+        async def warn(ctx):
+            await ctx.reply("Issuing warning...")
+
+        @bot.command()
+        @fluxer.checks.has_role(id=987654321098765432)
+        async def secret(ctx):
+            await ctx.reply("You found the secret command!")
+    """
+
+    def decorator(func: EventHandler) -> EventHandler:
+        @functools.wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> None:
+            # Make this compatible with both standalone commands and cog methods by checking
+            # if the first argument is a bot instance (Cog) or a context object (standalone)
+            a: list[Any] = list(args)
+            ctx: Message = a[1] if a and hasattr(a[0], "bot") else a[0]
+
+            if ctx.guild_id is None:
+                await ctx.reply("This command can only be used in a server.")
+                return
+
+            if name is None and id is None:
+                await ctx.reply("Invalid role requirement configuration.")
+                return
+
+            if ctx._http is None:
+                raise RuntimeError("HTTPClient is required to check roles")
+
+            member_data = await ctx._http.get_guild_member(ctx.guild_id, ctx.author.id)
+
+            role_id: int | None = None
+            if id is not None:
+                role_id = int(id)
+            elif name is not None:
+                roles_data = await ctx._http.get_guild_roles(ctx.guild_id)
+                role_id = next(
+                    (int(r["id"]) for r in roles_data if r["name"] == name),
+                    None,
+                )
+
+            member = GuildMember.from_data(member_data, ctx._http)
+            authorized = role_id is not None and member.has_role(role_id)
+
+            if not authorized:
+                await ctx.reply("You don't have permission to use this command.")
+                return
+
+            await func(*args, **kwargs)
+
+        for attr in ("__cog_command__", "__cog_command_name__"):
+            if hasattr(func, attr):
+                setattr(wrapper, attr, getattr(func, attr))
+
+        return wrapper
+
+    return decorator
+
+
+def has_permission(permission: Permissions) -> Callable[[EventHandler], EventHandler]:
+    """Restrict a command to members who have the specified permission(s).
+
+    Guild owners bypass this check unconditionally. Members with the
+    ADMINISTRATOR permission also bypass it.
+
+    Args:
+        permission: A Permissions flag, or multiple flags combined with |,
+                    that the member must have.
+
+    Example:
+        @bot.command()
+        @fluxer.checks.has_permission(Permissions.KICK_MEMBERS)
+        async def kick(ctx):
+            await ctx.reply("Kicking...")
+
+        @bot.command()
+        @fluxer.checks.has_permission(Permissions.KICK_MEMBERS | Permissions.BAN_MEMBERS)
+        async def punish(ctx):
+            await ctx.reply("You can kick and ban.")
+    """
+
+    def decorator(func: EventHandler) -> EventHandler:
+        @functools.wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> None:
+            # Make this compatible with both standalone commands and cog methods by checking
+            # if the first argument is a bot instance (Cog) or a context object (standalone)
+            a: list[Any] = list(args)
+            ctx: Message = a[1] if a and hasattr(a[0], "bot") else a[0]
+
+            if ctx.guild_id is None:
+                await ctx.reply("This command can only be used in a server.")
+                return
+
+            if ctx._http is None:
+                raise RuntimeError("HTTPClient is required to check permissions")
+
+            guild_data, member_data, roles_data = await asyncio.gather(
+                ctx._http.get_guild(ctx.guild_id),
+                ctx._http.get_guild_member(ctx.guild_id, ctx.author.id),
+                ctx._http.get_guild_roles(ctx.guild_id),
+            )
+
+            # If the user is the guild owner, they bypass all permission checks
+            if ctx.author.id == int(guild_data["owner_id"]):
+                await func(*args, **kwargs)
+                return
+
+            member_role_ids = {int(r) for r in member_data.get("roles", [])}
+            computed = 0
+            for role in roles_data:
+                role_id = int(role["id"])
+                if role_id == ctx.guild_id or role_id in member_role_ids:
+                    computed |= int(role["permissions"])
+
+            # If a user has admin, they bypass all permission checks
+            if computed & Permissions.ADMINISTRATOR:
+                await func(*args, **kwargs)
+                return
+
+            if (computed & int(permission)) != int(permission):
+                await ctx.reply("You don't have permission to use this command.")
+                return
+
+            await func(*args, **kwargs)
+
+        for attr in ("__cog_command__", "__cog_command_name__"):
+            if hasattr(func, attr):
+                setattr(wrapper, attr, getattr(func, attr))
+
+        return wrapper
+
+    return decorator

--- a/fluxer/enums.py
+++ b/fluxer/enums.py
@@ -132,3 +132,61 @@ class ChannelType(enum.IntEnum):
     GROUP_DM = 3
     GUILD_CATEGORY = 4
     GUILD_ANNOUNCEMENT = 5
+
+
+# =============================================================================
+# Permissions
+# =============================================================================
+
+
+class Permissions(enum.IntFlag):
+    """Permission bitfield flags for guild roles and channel overwrites.
+
+    Each member maps to a single bit in the permission integer stored on a
+    role or channel overwrite.  Use bitwise operators to combine or test flags:
+
+        Permissions.SEND_MESSAGES | Permissions.READ_MESSAGE_HISTORY
+        bool(role_permissions & Permissions.ADMINISTRATOR)
+    """
+
+    # -- General --
+    CREATE_INVITE = 1 << 0
+    KICK_MEMBERS = 1 << 1
+    BAN_MEMBERS = 1 << 2
+    ADMINISTRATOR = 1 << 3
+    MANAGE_CHANNELS = 1 << 4
+    MANAGE_GUILD = 1 << 5
+    ADD_REACTIONS = 1 << 6
+    VIEW_AUDIT_LOG = 1 << 7
+    PRIORITY_SPEAKER = 1 << 8
+    STREAM = 1 << 9
+    VIEW_CHANNEL = 1 << 10
+    SEND_MESSAGES = 1 << 11
+    SEND_TTS_MESSAGES = 1 << 12
+    MANAGE_MESSAGES = 1 << 13
+    EMBED_LINKS = 1 << 14
+    ATTACH_FILES = 1 << 15
+    READ_MESSAGE_HISTORY = 1 << 16
+    MENTION_EVERYONE = 1 << 17
+    USE_EXTERNAL_EMOJIS = 1 << 18
+    USE_EXTERNAL_STICKERS = 1 << 33
+    MODERATE_MEMBERS = 1 << 40
+    CREATE_EXPRESSIONS = 1 << 43
+    PIN_MESSAGES = 1 << 51
+    BYPASS_SLOWMODE = 1 << 52
+    UPDATE_RTC_REGION = 1 << 53
+
+    # -- Voice --
+    CONNECT = 1 << 20
+    SPEAK = 1 << 21
+    MUTE_MEMBERS = 1 << 22
+    DEAFEN_MEMBERS = 1 << 23
+    MOVE_MEMBERS = 1 << 24
+    USE_VOICE_ACTIVITY_DETECTION = 1 << 25
+
+    # -- Member management --
+    CHANGE_NICKNAME = 1 << 26
+    MANAGE_NICKNAMES = 1 << 27
+    MANAGE_ROLES = 1 << 28
+    MANAGE_WEBHOOKS = 1 << 29
+    MANAGE_EXPRESSIONS = 1 << 30


### PR DESCRIPTION
This PR adds two decorators for gating command execution:

`@fluxer.checks.has_role()` - Allows you to restrict running a command behind a specific role name or role id
`@fluxer.checks.has_permission()` - Allows you to restrict running a command behind a set of permissions, with by pass for guild owners and those with admin permissions