### PR TITLE
Improve Guild Caching

### DIFF
--- a/fluxer/client.py
+++ b/fluxer/client.py
@@ -257,7 +257,7 @@ class Client:
         if guild_id is not None:
             cached_guild = self._guilds.get(guild_id)
             if cached_guild:
-                msg._guild = cached_guild
+                msg._cache_guild(cached_guild)
         return msg
 
     async def _handle_reaction_add(self, data: dict[str, Any]) -> None:

--- a/fluxer/models/channel.py
+++ b/fluxer/models/channel.py
@@ -142,7 +142,7 @@ class Channel:
         )
         msg = Message.from_data(data, self._http)
         msg._channel = self
-        msg._guild = self._guild
+        msg._cache_guild(self._guild)
         return msg
 
     async def fetch_message(self, message_id: int | str) -> Message:
@@ -162,7 +162,7 @@ class Channel:
         data = await self._http.get_message(self.id, message_id)
         msg = Message.from_data(data, self._http)
         msg._channel = self
-        msg._guild = self._guild
+        msg._cache_guild(self._guild)
         return msg
 
     async def fetch_messages(self, limit: int = 50) -> list[Message]:
@@ -183,7 +183,7 @@ class Channel:
         msgs = [Message.from_data(msg_data, self._http) for msg_data in data]
         for msg in msgs:
             msg._channel = self
-            msg._guild = self._guild
+            msg._cache_guild(self._guild)
         return msgs
 
     async def delete_messages(self, message_ids: list[int | str]) -> None:

--- a/fluxer/models/message.py
+++ b/fluxer/models/message.py
@@ -26,7 +26,7 @@ class Message:
     author: User
     timestamp: str
     edited_timestamp: str | None = None
-    guild_id: int | None = None
+
     embeds: list[dict[str, Any]] = field(default_factory=list)
     attachments: list[Attachment] = field(default_factory=list)
     mentions: list[User] = field(default_factory=list)
@@ -56,7 +56,6 @@ class Message:
             author=author,
             timestamp=data["timestamp"],
             edited_timestamp=data.get("edited_timestamp"),
-            guild_id=int(data["guild_id"]) if data.get("guild_id") else None,
             embeds=data.get("embeds", []),
             attachments=attachments,
             mentions=mentions,
@@ -90,6 +89,11 @@ class Message:
     def guild(self) -> Guild | None:
         """The guild this message was sent in (if cached)."""
         return self._guild
+
+    @property
+    def guild_id(self) -> int | None:
+        """Shortcut for self.guild.id, created for backwards compatiblity"""
+        return self._guild.id if self._guild else None
 
     @staticmethod
     def _process_embed_args(kwargs: dict[str, Any]) -> dict[str, Any]:
@@ -166,7 +170,7 @@ class Message:
         )
         msg = Message.from_data(data, self._http)
         msg._channel = self._channel
-        msg._guild = self._guild
+        msg._cache_guild(self._guild)
         return msg
 
     async def reply(
@@ -223,7 +227,7 @@ class Message:
         )
         msg = Message.from_data(data, self._http)
         msg._channel = self._channel
-        msg._guild = self._guild
+        msg._cache_guild(self._guild)
         return msg
 
     async def send_to_channel(
@@ -272,7 +276,7 @@ class Message:
             channel_id, content=content, files=file_list, **combined_kwargs
         )
         msg = Message.from_data(data, self._http)
-        msg._guild = self._guild
+        msg._cache_guild(self._guild)
         return msg
 
     async def edit(self, content: str | None = None, **kwargs: Any) -> Message:
@@ -284,7 +288,7 @@ class Message:
         )
         msg = Message.from_data(data, self._http)
         msg._channel = self._channel
-        msg._guild = self._guild
+        msg._cache_guild(self._guild)
         return msg
 
     async def delete(self) -> None:
@@ -416,6 +420,12 @@ class Message:
                 return reaction
 
         raise ValueError(f"Reaction {emoji} not found on message")
+
+    def _cache_guild(self, guild: Guild | None) -> None:
+        """Set cached guild on this message and referenced_message, since replies can be assumed to be in same guild"""
+        self._guild = guild
+        if self.referenced_message is not None:
+            self.referenced_message._guild = guild
 
     def _clear_emoji(self, emoji: PartialEmoji) -> Reaction | None:
         """Internal method to clear all reactions of a specific emoji.


### PR DESCRIPTION
This PR does the following:
- Improves guild caching so that `referenced_message` gets the same `guild` attribute as the parent message, since it can be assumed a reply to a message will always be in the same guild
- Addresses https://github.com/akarealemil/fluxer.py/issues/45, we now use the ID from the cached guild object on a message since the API does not prove it.  