### PR TITLE
Fixed name representation for unicode emojis

### DIFF
--- a/fluxer/client.py
+++ b/fluxer/client.py
@@ -856,6 +856,10 @@ class Bot(Client):
                     cog_name,
                 )
             self._commands[cmd_name] = handler
+        
+        self._commands = dict(
+            sorted(self._commands.items(), key=lambda kv: len(kv[0]), reverse=True)
+        )  # sorts the dictionary in reverse key length order
 
         # Register cog's event listeners
         for event_name, listeners in cog._listeners.items():

--- a/fluxer/client.py
+++ b/fluxer/client.py
@@ -856,7 +856,7 @@ class Bot(Client):
                     cog_name,
                 )
             self._commands[cmd_name] = handler
-        
+
         self._commands = dict(
             sorted(self._commands.items(), key=lambda kv: len(kv[0]), reverse=True)
         )  # sorts the dictionary in reverse key length order

--- a/fluxer/models/reaction.py
+++ b/fluxer/models/reaction.py
@@ -28,7 +28,7 @@ class PartialEmoji:
         """Create a PartialEmoji from gateway data."""
         emoji_id = data.get("id")
         return cls(
-            name=data.get("name") if emoji_id else emoji.demojize(data.get("name")),
+            name=data.get("name") if emoji_id else emoji.demojize(data.get("name", "")),
             id=int(emoji_id) if emoji_id else None,
             animated=data.get("animated", False),
             unicode=data.get("name") if not emoji_id else None,

--- a/fluxer/models/reaction.py
+++ b/fluxer/models/reaction.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+import emoji
+
 if TYPE_CHECKING:
     from ..http import HTTPClient
     from .message import Message
@@ -19,15 +21,17 @@ class PartialEmoji:
     name: str | None = None
     id: int | None = None
     animated: bool = False
+    unicode: str | None = None
 
     @classmethod
     def from_data(cls, data: dict[str, Any]) -> PartialEmoji:
         """Create a PartialEmoji from gateway data."""
         emoji_id = data.get("id")
         return cls(
-            name=data.get("name"),
+            name=data.get("name") if emoji_id else emoji.demojize(data.get("name")),
             id=int(emoji_id) if emoji_id else None,
             animated=data.get("animated", False),
+            unicode=data.get("name") if not emoji_id else None,
         )
 
     @property


### PR DESCRIPTION
Previous implementation showed `PartialEmoji.name` as the unicode representation of emojis (`:taco:` shown as `🌮`).

This change allows the name to be shown as the emoji label used by members for easier identification and usage in this wrapper, allowing for a more consistent usage of `Message.add_reaction(emoji)` (since that one does receive an emoji represented as `:label:`)