### PR TITLE
add Client.get_guild

### DIFF
--- a/fluxer/client.py
+++ b/fluxer/client.py
@@ -67,6 +67,9 @@ class Client:
         """List of guilds the bot is in (populated from READY + GUILD_CREATE)."""
         return list(self._guilds.values())
 
+    def get_guild(self, id: int) -> Guild | None:
+        return self._guilds.get(id)
+
     # =========================================================================
     # Event registration
     # =========================================================================


### PR DESCRIPTION
There wasn't a method to get a guild from cache, `Client.guilds` would return a list and it'd be inconvenient for an ID lookup.

This adds a `Client.get_guild` method to expose the cache similar to what discord.py also offers.