### PR TITLE
Standarized embed handling for message.send and channel.send

### DIFF
--- a/fluxer/models/channel.py
+++ b/fluxer/models/channel.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
+from fluxer.utils import process_embed_args
 
 from ..enums import ChannelType
 from ..utils import snowflake_to_datetime
@@ -119,12 +120,10 @@ class Channel:
 
         if self._http is None:
             raise RuntimeError("Channel is not bound to an HTTP client")
-
-        embed_list: list[dict[str, Any]] | None = None
-        if embed:
-            embed_list = [embed.to_dict()]
-        elif embeds:
-            embed_list = [e.to_dict() for e in embeds]
+        
+        # Auto-convert single embed to embeds list
+        combined_kwargs = {"embed": embed, "embeds": embeds}
+        combined_kwargs = process_embed_args(combined_kwargs)
 
         # Handle file/files parameter - convert File objects to dict format
         file_list: list[dict[str, Any]] | None = None
@@ -136,9 +135,9 @@ class Channel:
         data = await self._http.send_message(
             self.id,
             content=content,
-            embeds=embed_list,
             files=file_list,
             message_reference=message_reference,
+            **combined_kwargs,
         )
         msg = Message.from_data(data, self._http)
         msg._channel = self

--- a/fluxer/models/channel.py
+++ b/fluxer/models/channel.py
@@ -120,7 +120,7 @@ class Channel:
 
         if self._http is None:
             raise RuntimeError("Channel is not bound to an HTTP client")
-        
+
         # Auto-convert single embed to embeds list
         combined_kwargs = {"embed": embed, "embeds": embeds}
         combined_kwargs = process_embed_args(combined_kwargs)

--- a/fluxer/models/message.py
+++ b/fluxer/models/message.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
+from fluxer.utils import process_embed_args
 
 from ..utils import snowflake_to_datetime
 
@@ -95,36 +96,6 @@ class Message:
         """Shortcut for self.guild.id, created for backwards compatiblity"""
         return self._guild.id if self._guild else None
 
-    @staticmethod
-    def _process_embed_args(kwargs: dict[str, Any]) -> dict[str, Any]:
-        """Process embed/embeds arguments to ensure proper format.
-
-        Converts:
-        - embed=Embed(...) -> embeds=[{...}]
-        - embeds=[Embed(...)] -> embeds=[{...}]
-        - embeds=[{...}] -> embeds=[{...}] (no change)
-        """
-        from .embed import Embed
-
-        # Handle singular 'embed' parameter
-        if "embed" in kwargs:
-            embed = kwargs.pop("embed")
-            if embed is not None:
-                # Convert Embed object to dict
-                if isinstance(embed, Embed):
-                    kwargs["embeds"] = [embed.to_dict()]
-                else:
-                    # Assume it's already a dict
-                    kwargs["embeds"] = [embed]
-
-        # Handle plural 'embeds' parameter - convert any Embed objects to dicts
-        if "embeds" in kwargs and kwargs["embeds"] is not None:
-            kwargs["embeds"] = [
-                e.to_dict() if isinstance(e, Embed) else e for e in kwargs["embeds"]
-            ]
-
-        return kwargs
-
     async def send(
         self,
         content: str | None = None,
@@ -153,7 +124,7 @@ class Message:
 
         # Auto-convert single embed to embeds list
         combined_kwargs = {"embed": embed, "embeds": embeds, **kwargs}
-        combined_kwargs = self._process_embed_args(combined_kwargs)
+        combined_kwargs = process_embed_args(combined_kwargs)
 
         # Handle file/files parameter - convert File objects to dict format
         file_list: list[dict[str, Any]] | None = None
@@ -201,7 +172,7 @@ class Message:
 
         # Auto-convert single embed to embeds list
         combined_kwargs = {"embed": embed, "embeds": embeds, **kwargs}
-        combined_kwargs = self._process_embed_args(combined_kwargs)
+        combined_kwargs = process_embed_args(combined_kwargs)
 
         # Handle file/files parameter - convert File objects to dict format
         file_list: list[dict[str, Any]] | None = None
@@ -263,7 +234,7 @@ class Message:
 
         # Auto-convert single embed to embeds list
         combined_kwargs = {"embed": embed, "embeds": embeds, **kwargs}
-        combined_kwargs = self._process_embed_args(combined_kwargs)
+        combined_kwargs = process_embed_args(combined_kwargs)
 
         # Handle file/files parameter - convert File objects to dict format
         file_list: list[dict[str, Any]] | None = None

--- a/fluxer/utils.py
+++ b/fluxer/utils.py
@@ -5,7 +5,9 @@ import pkgutil
 import re
 from collections.abc import Iterator
 from datetime import datetime, timezone
-from typing import Literal
+from typing import Any, Literal
+
+from .models.embed import Embed
 
 # Fluxer uses the same epoch as Discord: 2015-01-01T00:00:00Z
 FLUXER_EPOCH = 1420070400000
@@ -237,3 +239,31 @@ def search_directory(path: str) -> Iterator[str]:
             yield from search_directory(os.path.join(path, name))
         else:
             yield prefix + name
+
+def process_embed_args(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Process embed/embeds arguments to ensure proper format.
+
+    Converts:
+    - embed=Embed(...) -> embeds=[{...}]
+    - embeds=[Embed(...)] -> embeds=[{...}]
+    - embeds=[{...}] -> embeds=[{...}] (no change)
+    """
+
+    # Handle singular 'embed' parameter
+    if "embed" in kwargs:
+        embed = kwargs.pop("embed")
+        if embed is not None:
+            # Convert Embed object to dict
+            if isinstance(embed, Embed):
+                kwargs["embeds"] = [embed.to_dict()]
+            else:
+                # Assume it's already a dict
+                kwargs["embeds"] = [embed]
+
+    # Handle plural 'embeds' parameter - convert any Embed objects to dicts
+    if "embeds" in kwargs and kwargs["embeds"] is not None:
+        kwargs["embeds"] = [
+            e.to_dict() if isinstance(e, Embed) else e for e in kwargs["embeds"]
+        ]
+
+    return kwargs

--- a/fluxer/utils.py
+++ b/fluxer/utils.py
@@ -240,6 +240,7 @@ def search_directory(path: str) -> Iterator[str]:
         else:
             yield prefix + name
 
+
 def process_embed_args(kwargs: dict[str, Any]) -> dict[str, Any]:
     """Process embed/embeds arguments to ensure proper format.
 


### PR DESCRIPTION
## Summary

<!-- Longer description of the changes and why they are needed -->

Previous implementation handled embeds differently in `message.send(...)` and `channel.send(...)`.

New implementation standardizes handling to make `embed` and `embeds` args into a single `combined_kwargs` arg for later `_http.send_message(...)` usage

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->
- [x] I am following the [Contribution Guidelines](https://github.com/akarealemil/fluxer.py/blob/development/.github/CONTRIBUTING.md)

- [x] These changes modify code
  - [x] All code changes have been tested.
  - [x] This Pull Request contains breaking changes (such as removing/renaming methods or parameters)
  - [x] I ran a Ruff Formatting check
  - [x] I ran a Type Check
  <!-- - [ ] My code is properly documented (comments and doc-strings) -->
  <!-- - [ ] The documentation has been updated according to my changes.  -->

- [ ] This Pull Request fixes an issue.
- [ ] This Pull Request adds one or more features.