### PR TITLE
Add Setup Hook to Client

### DIFF
--- a/fluxer/client.py
+++ b/fluxer/client.py
@@ -533,6 +533,12 @@ class Client:
         assert self._http is not None
         await self._http.delete_all_reactions_for_emoji(channel_id, message_id, emoji)
 
+    async def setup_hook(self) -> None:
+        """Called before connecting to the gateway.
+
+        Override this to perform setup tasks before the client starts receiving events.
+        """
+
     # =========================================================================
     # Connection lifecycle
     # =========================================================================
@@ -561,6 +567,8 @@ class Client:
             intents=self.intents,
             dispatch=self._dispatch,
         )
+
+        await self.setup_hook()
 
         try:
             await self._gateway.connect()


### PR DESCRIPTION
## Summary

This PR adds a setup hook for the client that allows for performing setup tasks before the client starts receiving events if it is subclassed. 

Fixes #66 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->
- [x] I am following the [Contribution Guidelines](https://github.com/akarealemil/fluxer.py/blob/development/.github/CONTRIBUTING.md)

- [x] These changes modify code
  - [x] All code changes have been tested.
  - [ ] This Pull Request contains breaking changes (such as removing/renaming methods or parameters)
  - [x] I ran a Ruff Formatting check
  - [x] I ran a Type Check

- [ ] This Pull Request fixes an issue.
- [x] This Pull Request adds one or more features.