### PR TITLE
Reconnect On Websocket Closure

### DIFF
--- a/fluxer/gateway.py
+++ b/fluxer/gateway.py
@@ -250,8 +250,7 @@ class Gateway:
     async def _send(self, payload: GatewayPayload) -> None:
         """Send a payload over the WebSocket."""
         if self._ws is None or self._ws.closed:
-            log.warning("Tried to send on closed WebSocket")
-            return
+            raise ConnectionError("Tried to send on closed WebSocket")
         raw = payload.to_json()
         log.debug("Sending: %s", payload)
         await self._ws.send_str(raw)
@@ -326,7 +325,15 @@ class Gateway:
                     return
 
                 self._last_heartbeat_ack = False
-                await self._send_heartbeat()
+                try:
+                    await self._send_heartbeat()
+                except Exception as e:
+                    log.warning(
+                        f"Failed to send heartbeat due to exception: {e}, closing to trigger reconnect"
+                    )
+                    if self._ws and not self._ws.closed:
+                        await self._ws.close(code=4000)
+                    return
                 await asyncio.sleep(self._heartbeat_interval)
         except asyncio.CancelledError:
             pass


### PR DESCRIPTION
## Summary

Currently if we try to send on a closed websocket, we log it but silently return which prevents any reconnection attempts. This PR changes this behavior to throw an exception that we then handle by closing on the client side and reconnecting. 

Fixes #62 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->
- [x] I am following the [Contribution Guidelines](https://github.com/akarealemil/fluxer.py/blob/development/.github/CONTRIBUTING.md)

- [x] These changes modify code
  - [x] All code changes have been tested.
  - [ ] This Pull Request contains breaking changes (such as removing/renaming methods or parameters)
  - [x] I ran a Ruff Formatting check
  - [x] I ran a Type Check

- [x] This Pull Request fixes an issue.
- [ ] This Pull Request adds one or more features.