### PR TITLE
Added escape_mentions utility method

### DIFF
--- a/fluxer/utils.py
+++ b/fluxer/utils.py
@@ -268,3 +268,13 @@ def process_embed_args(kwargs: dict[str, Any]) -> dict[str, Any]:
         ]
 
     return kwargs
+
+
+def escape_mentions(text: str) -> str:
+    """A helper function that escapes everyone, here, role, and user mentions.
+
+    .. note::
+
+        This does not include channel mentions.
+    """
+    return re.sub(r"@(everyone|here|[!&]?[0-9]{17,20})", "@\u200b\\1", text)


### PR DESCRIPTION
## Summary

Added a `escape_mentions` utility method that suppresses pings from messages by adding a zero-width space right after any mentioning @

Closes #70 (Implemented feature)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->
- [x] I am following the [Contribution Guidelines](https://github.com/akarealemil/fluxer.py/blob/development/.github/CONTRIBUTING.md)

- [x] These changes modify code
  - [x] All code changes have been tested.
  - [ ] This Pull Request contains breaking changes (such as removing/renaming methods or parameters)
  - [x] I ran a Ruff Formatting check
  - [x] I ran a Type Check
  <!-- - [ ] My code is properly documented (comments and doc-strings) -->
  <!-- - [ ] The documentation has been updated according to my changes.  -->

- [x] This Pull Request fixes an issue.
- [x] This Pull Request adds one or more features.