### PR TITLE
Limited workflow executions

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,8 +3,12 @@ name: Format Check
 on:
   push:
     branches: [main]
+    paths:
+    - '**.py'
   pull_request:
     branches: [main, development]
+    paths:
+    - '**.py'
 
 jobs:
   format:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,8 +3,12 @@ name: Linting
 on:
   push:
     branches: [main, test, dev]
+    paths:
+    - '**.py'
   pull_request:
     branches: [main, development]
+    paths:
+    - '**.py'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,17 @@ name: Tests
 on:
   push:
     branches: [main, test, dev]
+    paths:
+    - '**.py'
+    - 'pyproject.toml'
+    - 'uv.lock'
+
   pull_request:
     branches: [main, development]
+    paths:
+    - '**.py'
+    - 'pyproject.toml'
+    - 'uv.lock'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Limited workflow checks to run only when python files were changed.
Tests still run when execution related files were changed (`pyproject.toml` or `uv.lock`)

I don't like spam in my email about failed tests when my changes are only docs/github related :(

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->
- [x] I am following the [Contribution Guidelines](https://github.com/akarealemil/fluxer.py/blob/development/.github/CONTRIBUTING.md)

- [ ] These changes modify code
  - [ ] All code changes have been tested.
  - [ ] This Pull Request contains breaking changes (such as removing/renaming methods or parameters)
  - [ ] I ran a Ruff Formatting check
  - [ ] I ran a Type Check
  <!-- - [ ] My code is properly documented (comments and doc-strings) -->
  <!-- - [ ] The documentation has been updated according to my changes.  -->

- [ ] This Pull Request fixes an issue.
- [ ] This Pull Request adds one or more features.